### PR TITLE
fix css bug

### DIFF
--- a/source/css/_main-r.styl
+++ b/source/css/_main-r.styl
@@ -7,6 +7,8 @@
 @media (min-width: 768px) and (max-width: 979px)
   body
     margin: 30px
+    margin-top: 0px;
+    margin-bottom: 0px;
   .head
   .main
   .foot
@@ -18,8 +20,7 @@
 
 @media (max-width: 767px)
   body
-    margin-left: 20px
-    margin-right: 20px
+    margin: 20px
     margin-bottom: 0px
     margin-top: 0px
     font-size: font-size-rem($base-font-size-r)

--- a/source/css/_main-r.styl
+++ b/source/css/_main-r.styl
@@ -18,7 +18,8 @@
 
 @media (max-width: 767px)
   body
-    margin: 20px
+    margin-left: 20px
+    margin-right: 20px
     margin-bottom: 0px
     margin-top: 0px
     font-size: font-size-rem($base-font-size-r)

--- a/source/css/_main-r.styl
+++ b/source/css/_main-r.styl
@@ -19,6 +19,8 @@
 @media (max-width: 767px)
   body
     margin: 20px
+    margin-bottom: 0px
+    margin-top: 0px
     font-size: font-size-rem($base-font-size-r)
 
   .head


### PR DESCRIPTION
首页在手机端并不是占据整个屏幕的，而是可以上下的滑动，导致中间的蓝色区域不能居中。

修改后，首页上下固定不会滑动。

> 修改前：

![_ _20170408224325](https://cloud.githubusercontent.com/assets/20165605/24829880/3e93343c-1c40-11e7-8097-71eee02abbda.gif)

> 修改后：

![_ _20170408224357](https://cloud.githubusercontent.com/assets/20165605/24829881/3ed84e78-1c40-11e7-8340-96f150ad0962.gif)
